### PR TITLE
Support starting the node proc with HTTPs support.

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -27,6 +27,15 @@ module.exports = {
     clientId: 'YOUR_STRIPE_CLIENT_ID',
   },
 
+  //sslKey: '/path/to/private/key',
+  //sslCrt: '/path/to/crt',
+  
+  // This is optional when enabling HTTPs support
+  //caCrt: '/path/to/ca',
+
+  // Is a redirect from HTTP (TCP 80) needed? Note that you can only start a listener on TCP 80 as a super user since it's a well known port
+  redirectHttp: false,
+
   // Configuration for MongoDB
   mongoUri: 'mongodb://localhost/rocketdeliveries',
 


### PR DESCRIPTION

This is needed when you wish to use a non-test Stripe account [aka `livemode`] with `registerWebhooks:true` (the default) without setting up a proxy server/load balancer, since, if not running over HTTPs, the code will fail with:

```
Error registering webhook: StripeInvalidRequestError: Invalid URL: undefined/pilots/stripe/webhooks. URLs in livemode must begin with "https://"
    at Function.generate (/tmp/stripe-connect-custom-rocketdeliveries/node_modules/stripe/lib/Error.js:49:16)
    at IncomingMessage.<anonymous> (/tmp/stripe-connect-custom-rocketdeliveries/node_modules/stripe/lib/StripeResource.js:167:39)
    at Object.onceWrapper (events.js:420:28)
    at IncomingMessage.emit (events.js:326:22)
    at endReadableNT (_stream_readable.js:1241:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  raw: {
    message: 'Invalid URL: undefined/pilots/stripe/webhooks. URLs in livemode must begin with "https://"',
    type: 'invalid_request_error',
```

